### PR TITLE
fix tls issue on ingress chart

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -21,13 +21,13 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ include "cacheppuccino.fullname" $ }}
+                name: {{ include "cacheppuccino.fullname" . }}
                 port:
                   number: 8080
   {{- if .Values.ingress.tls.enabled }}
-    tls:
-      - hosts:
-        - {{ .Values.ingress.host }}
-        secretName: {{ .Values.ingress.tls.secretName }}
+  tls:
+    - secretName: {{ required "ingress.tls.secretName" .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.ingress.host | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## changes
- Fix ingress tls issue.

## Output
Helm template 

```
---
# Source: cacheppuccino-helm/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ifrcgo-cacheppuccino
  labels:
    helm.sh/chart: cacheppuccino-helm-0.1.0
    app.kubernetes.io/name: cacheppuccino-helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  rules:
    - host: "cacheppuccino.ifrc.org"
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: ifrcgo-cacheppuccino
                port:
                  number: 8080
  tls:
    - secretName: secret-cert
      hosts:
        - "cacheppuccino.ifrc.org"
```